### PR TITLE
Recursively search for packages, stripping subfolders on each go

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,11 @@ export function activate(context: ExtensionContext) {
       deferred.resolve(nodeModules.getApiUrl(packageName));
     }
     
-    http.get('http://registry.npmjs.org/' + packageName, (response: http.ClientResponse) => {
+    let packageTry = packageName;
+    
+    do{
+    
+    http.get('http://registry.npmjs.org/' + packageTry, (response: http.ClientResponse) => {
       let body: string = '';
       
       response.on('data', (d) => {
@@ -83,13 +87,18 @@ export function activate(context: ExtensionContext) {
           
           url = url.substr(url.indexOf('http'));
           deferred.resolve(url);
-        } else {
-          deferred.reject('No repository found!');
         }
       });
     }).on('error', (err) => {
       deferred.reject(err.message);
     });
+    
+    sliceTo = Math.max( packageTry.lastIndexOf('/'), 0 );
+    packageTry = packageTry.slice(0, sliceTo);
+    
+    } while (packageTry);
+    
+    deferred.reject('No repository found!');
     
     return deferred.promise;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,38 +68,38 @@ export function activate(context: ExtensionContext) {
     
     do{
     
-    http.get('http://registry.npmjs.org/' + packageTry, (response: http.ClientResponse) => {
-      let body: string = '';
-      
-      response.on('data', (d) => {
-        body += d;
-      });
-      
-      response.on('end', () => {
-        const responseJson = JSON.parse(body);
+      http.get('http://registry.npmjs.org/' + packageTry, (response: http.ClientResponse) => {
+        let body: string = '';
         
-        if (responseJson.repository && responseJson.repository.url) {
-          let url = responseJson.repository.url;
-          if (url.indexOf('http') === -1 ) {
-            deferred.reject('Invalid project url');
-            return;
-          }
+        response.on('data', (d) => {
+          body += d;
+        });
+        
+        response.on('end', () => {
+          const responseJson = JSON.parse(body);
           
-          url = url.substr(url.indexOf('http'));
-          deferred.resolve(url);
-        }
+          if (responseJson.repository && responseJson.repository.url) {
+            let url = responseJson.repository.url;
+            if (url.indexOf('http') === -1 ) {
+              deferred.reject('Invalid project url');
+              return;
+            }
+            
+            url = url.substr(url.indexOf('http'));
+            deferred.resolve(url);
+          }
+        });
+      }).on('error', (err) => {
+        deferred.reject(err.message);
       });
-    }).on('error', (err) => {
-      deferred.reject(err.message);
-    });
-    
-    sliceTo = Math.max( packageTry.lastIndexOf('/'), 0 );
-    packageTry = packageTry.slice(0, sliceTo);
+      
+      if (!packageTry) deferred.reject('No repository found!');
+
+      let sliceTo = Math.max( packageTry.lastIndexOf('/'), 0 );
+      packageTry = packageTry.slice(0, sliceTo);
     
     } while (packageTry);
-    
-    deferred.reject('No repository found!');
-    
+        
     return deferred.promise;
   }
   


### PR DESCRIPTION
A la the issue I created #1

I haven't tested this (no idea what the build process is for vscode extensions) but it's a pretty simple mod. The extension keeps checking for modules, removing the last subfolder on each iteration until there are no more slashes in the module name.
